### PR TITLE
Making possible to add rules via docker secret

### DIFF
--- a/prometheus/config.go
+++ b/prometheus/config.go
@@ -33,10 +33,12 @@ func WriteConfig(configPath string, scrapes map[string]Scrape,
 		c.InsertScrapesFromDir(configsDir)
 	}
 
+	c.RuleFiles = []string{"/run/secrets/*.rules"}
 	if len(alerts) > 0 {
 		logPrintf("Writing to alert.rules")
 		afero.WriteFile(FS, alertRulesPath, []byte(GetAlertConfig(alerts)), 0644)
-		c.RuleFiles = []string{"alert.rules"}
+		// c.RuleFiles = []string{"alert.rules"}
+		c.RuleFiles = append(c.RuleFiles, "alert.rules")
 	}
 
 	alertmanagerURLs := os.Getenv("ARG_ALERTMANAGER_URL")
@@ -66,7 +68,6 @@ func WriteConfig(configPath string, scrapes map[string]Scrape,
 	logPrintf("Writing to prometheus.yml")
 	configYAML, _ := yaml.Marshal(c)
 	afero.WriteFile(FS, configPath, configYAML, 0644)
-
 }
 
 // InsertEnv inserts envKey/envValue into config

--- a/prometheus/config_test.go
+++ b/prometheus/config_test.go
@@ -848,7 +848,7 @@ func (s *ConfigTestSuite) Test_WriteConfig_WriteAlerts() {
 	}
 
 	c := &Config{}
-	c.RuleFiles = []string{"alert.rules"}
+	c.RuleFiles = []string{"/run/secrets/*.rules", "alert.rules"}
 	cYAML, _ := yaml.Marshal(c)
 	expectedAlerts := GetAlertConfig(alerts)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -137,6 +137,8 @@ alerting:
     - targets:
       - alert-manager:9093
     scheme: http
+rule_files:
+- /run/secrets/*.rules
 `
 	fsOrig := prometheus.FS
 	defer func() { prometheus.FS = fsOrig }()
@@ -952,6 +954,7 @@ alerting:
       - alert-manager:9093
     scheme: http
 rule_files:
+- /run/secrets/*.rules
 - alert.rules
 scrape_configs:
 - job_name: my-service
@@ -995,6 +998,7 @@ alerting:
       - alert-manager:9093
     scheme: http
 rule_files:
+- /run/secrets/*.rules
 - alert.rules
 scrape_configs:
 - job_name: my-service
@@ -1271,6 +1275,8 @@ alerting:
     - targets:
       - alert-manager:9093
     scheme: http
+rule_files:
+- /run/secrets/*.rules
 scrape_configs:
 - job_name: my-service
   metrics_path: /metrics
@@ -1301,6 +1307,8 @@ alerting:
     - targets:
       - alert-manager:9093
     scheme: http
+rule_files:
+- /run/secrets/*.rules
 `
 	addr = "/v1/docker-flow-monitor?serviceName=my-service"
 	req, _ = http.NewRequest("DELETE", addr, nil)
@@ -1450,6 +1458,8 @@ alerting:
     - targets:
       - alert-manager:9093
     scheme: http
+rule_files:
+- /run/secrets/*.rules
 `
 
 	actualConfig, _ := afero.ReadFile(prometheus.FS, "/etc/prometheus/prometheus.yml")


### PR DESCRIPTION
I am using DFM to monitoring my docker swarm cluster, and I am also using it to monitoring machines that are outside docker swarm. I know it is possible to create scrapes files, although rules files were not possible. I did some changes, and now it is possible to create rules files as docker secrets, the filename needs to have `.rules` as a suffix. 

Below you will find an example:

Creating a new rule file:
```bash
echo 'groups:
- name: node.rules
  rules:
  - alert: instance_down
    expr: up == 0
    for: 5m
    labels:
      severity: high
    annotations:
      summary: "Instance {{$labels.instance}} down"
      description: "{{$labels.instance}} of job {{$labels.job}} has been down for more than 5 minutes."
  - alert: disk_will_fill_in_4_hours
    expr: predict_linear(node_filesystem_free{service="exporter_node-exporter",fstype="ext4"}[1h], 4 * 3600) < 0
    for: 5m
    labels:
      severity: high
    annotations:
      summary: "Disk will fill in 4 hours in the {{$labels.node}}"
      description: "The {{$labels.device}} disk in the {{$labels.node}} node will fill in 4 hours." ' | docker secret create node.rules -
```

Adding it to docker-flow-monitor.yml file:
```yaml
version: "3"
services:
  monitor:
    image: dockerflow/docker-flow-monitor:${TAG:-latest}
    environment:
      - GLOBAL_SCRAPE_INTERVAL=10s
    secrets:
      - node.rules
    networks:
      - monitor
    ports:
      - 9090:9090
networks:
    monitor:
       external: true
secrets:
  node.rules:
    external: true
```

I don't know if you want to have this feature, but considering that I did the change, I would like to share it. If this change is ok for you, I can also update the documentation.
